### PR TITLE
Implement monitoring of new emails

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 #
 from mycroft import MycroftSkill, intent_file_handler
+from datetime import datetime
 import sys
 import imaplib
 import email
 import email.header
+import email.utils
 
-def list_new_email(account, folder, password, port, address):
+EMAIL_POLL_INTERVAL = 120 # in seconds
+
+def list_new_email(account, folder, password, port, address, whitelist = None, mark_as_seen = False):
     """
     Returns new emails.
     output:
@@ -35,10 +39,20 @@ def list_new_email(account, folder, password, port, address):
         msg = email.message_from_bytes(data[0][1])
         hdr = email.header.make_header(email.header.decode_header(msg['Subject']))#Get subject
         sender = email.header.make_header(email.header.decode_header(msg['From']))#Get sender
-        M.store(num, "-FLAGS", '\\SEEN') #Some email providers automaticly mark a message as seen: undo that.
+        from_email = email.utils.parseaddr(msg['From'])[1]
         subject = str(hdr)
         sender = str(sender)
+
+        is_in_whitelist = not whitelist or from_email in whitelist or any(s.lower() in sender.lower().split(" ") for s in whitelist)
+        if is_in_whitelist and mark_as_seen:
+            M.store(num, "+FLAGS", '\\SEEN')
+        else:
+            M.store(num, "-FLAGS", '\\SEEN') #Some email providers automaticly mark a message as seen: undo that.
         mail = {"message_num": message_num, "sender": sender, "subject": subject}
+        if not is_in_whitelist:
+            # The user does not want emails from that sender, skip it
+            continue
+        
         new_emails.append(mail)
         message_num += 1
     #Clean up
@@ -46,6 +60,22 @@ def list_new_email(account, folder, password, port, address):
     M.logout()
 
     return new_emails
+
+def normalize_email(email):
+    if not email:
+        return None
+    
+    result = ""
+
+    for token in email.split():
+        if token == "dot":
+            result += "."
+        elif token == "at":
+            result += "@"
+        else:
+            result += token
+
+    return result
 
 class Email(MycroftSkill):
     """The email skill
@@ -55,6 +85,141 @@ class Email(MycroftSkill):
         """Init"""
         MycroftSkill.__init__(self)
 
+    def initialize(self):
+        # Start the notification service if it was active when Mycroft quit
+        self.remove_event('poll.emails')
+        if self.settings.get('look_for_mail'):
+            self.schedule_repeating_event(self.poll_emails, datetime.now(), EMAIL_POLL_INTERVAL, name='poll.emails')
+
+    def poll_emails(self, data):
+        account = self.settings.get('username')
+        password = self.settings.get('password')
+        server = self.settings.get("server")
+        if account == None or account == "" or server == None or server == "":
+            config = self.config_core.get("email_login", {})
+            account = config.get("email")#Get settings in config file
+            password = config.get("password")
+            if account == None or account == "" or password == "" or password == None:
+                #Not set up in file/home
+                return
+        folder = self.settings.get('folder')
+        port = self.settings.get("port")
+        setting = self.settings.get('look_for_email')
+        #check email
+        try:
+            new_emails = list_new_email(account=account, folder=folder, password=password, port=port, address=server, whitelist = setting['whitelist'], mark_as_seen = True)
+        except Exception as e:
+            # Silently ignore errors
+            return
+
+        if not new_emails:
+            # No new mail
+            return
+        
+        stop_num = 10
+        num_emails = len(new_emails)
+        response = self.ask_yesno(prompt="notify.read.email", data={"size" : num_emails})
+        if response != "yes":
+            return
+        
+        #report back
+        for x in range(num_emails):
+            new_email = new_emails[x]
+            self.speak_dialog("list.subjects", data=new_email)
+
+            #Say 10 emails, if more ask if user wants to hear them
+            if x == stop_num:
+                more = self.ask_yesno(prompt="more.emails")
+                if more == "no":
+                    self.speak_dialog("no.more.emails")
+                    break
+                elif more == "yes":
+                    stop_num += 10
+                    continue
+            
+    @intent_file_handler('notify.intent')
+    def enable_email_polling(self, message):
+        sender = normalize_email(message.data.get('sender'))
+        setting = self.settings.get('look_for_email')
+        if not setting:
+            # The email notification service is not active yet
+            if sender:
+                self.settings['look_for_email'] = { "whitelist" : [sender] }
+            else:
+                self.settings['look_for_email'] = { "whitelist" : None }
+                
+            # Start the notification service
+            self.schedule_repeating_event(self.poll_emails, datetime.now(), EMAIL_POLL_INTERVAL, name='poll.emails')
+            self.speak_dialog("start.poll.email")
+        else:
+            if not setting['whitelist'] and sender:
+                # The user request that we look for a specific email, but we are already notifying all incoming mails
+                # Ask if the user wants to limit the notifications to that email
+                replace = self.ask_yesno(prompt="cancel.looking.for.all.look.specific", data={"email" : sender})
+                if replace == "yes":
+                    setting['whitelist'] = [sender]
+                else:
+                    # We did not change anything, so the event data does not need to be updated
+                    return
+            elif not setting['whitelist'] and not sender:
+                # We were requested to look for all emails, but we are already doing that
+                self.speak_dialog("already.looking.for.all")
+                return
+            elif sender in setting['whitelist']:
+                # We were requested to look for emails by a specific person, but we are already doing that
+                self.speak_dialog("already.looking.for.specific", data={"email" : sender})
+                return
+            elif setting['whitelist'] and not sender:
+                replace = self.ask_yesno(prompt="cancel.looking.for.specific.look.all", data={"email" : setting['whitelist']})
+                if replace == "yes":
+                    setting['whitelist'] = None
+                else:
+                    # We did not change anything, so the event data does not need to be updated
+                    return
+            else:
+                setting['whitelist'].append(sender)
+            
+            self.speak_dialog("update.notify.data")
+        self.settings.store()
+
+    @intent_file_handler('stop.intent')
+    def disable_email_polling(self, message):
+        if not self.settings.get('look_for_email'):
+            self.speak_dialog("poll.emails.not.started")
+            return
+
+        sender = normalize_email(message.data.get('sender'))
+
+        if not sender:
+            self.settings['look_for_email'] = None
+            self.remove_event('poll.emails')
+            self.speak_dialog("stop.poll.emails")
+        else:
+            # We are looking for all new emails, turn it off completely
+            if not self.settings['look_for_email']['whitelist']:
+                self.settings['look_for_email'] = None
+                self.remove_event('poll.emails')
+                self.speak_dialog("stop.poll.emails")
+                self.settings.store()
+                return
+
+            # Do we even look for that sender?
+            if not sender in self.settings['look_for_email']['whitelist']:
+                self.speak_dialog("not.looking.for", data={"email" : sender})
+                return
+
+            if len(self.settings['look_for_email']['whitelist']) > 1:
+                # Remove the sender from the whitelist
+                self.settings['look_for_email']['whitelist'].remove(sender)
+                self.speak_dialog("stop.looking.for", data={"email" : sender})
+            else:
+                # We don't have any email addresses to look for, so turn it off completely
+                self.settings['look_for_email'] = None
+                self.remove_event('poll.emails')
+                self.speak_dialog("stop.poll.emails.last.email.removed")
+        
+        self.settings.store()
+            
     @intent_file_handler('check.email.intent')
     def handle_email(self, message):
        """Get the new emails and speak it"""

--- a/dialog/en-us/already.looking.for.all.dialog
+++ b/dialog/en-us/already.looking.for.all.dialog
@@ -1,0 +1,1 @@
+I'm already looking for new mail.

--- a/dialog/en-us/already.looking.for.specific.dialog
+++ b/dialog/en-us/already.looking.for.specific.dialog
@@ -1,0 +1,1 @@
+I'm already looking for emails from {email}

--- a/dialog/en-us/cancel.looking.for.all.look.specific.dialog
+++ b/dialog/en-us/cancel.looking.for.all.look.specific.dialog
@@ -1,0 +1,1 @@
+I currently look for all new mail, do you want me to only notify you of emails by {email}

--- a/dialog/en-us/cancel.looking.for.specific.look.all.dialog
+++ b/dialog/en-us/cancel.looking.for.specific.look.all.dialog
@@ -1,0 +1,1 @@
+I am currently looking for {email}, do you want me to look for all new mail instead?

--- a/dialog/en-us/not.looking.for.dialog
+++ b/dialog/en-us/not.looking.for.dialog
@@ -1,0 +1,1 @@
+I'm currently not looking for emails by {email}

--- a/dialog/en-us/notify.read.email.dialog
+++ b/dialog/en-us/notify.read.email.dialog
@@ -1,0 +1,1 @@
+You have {size} new email, do you want to hear it?

--- a/dialog/en-us/poll.emails.not.started.dialog
+++ b/dialog/en-us/poll.emails.not.started.dialog
@@ -1,0 +1,1 @@
+I currently do not look for new mail.

--- a/dialog/en-us/start.poll.email.dialog
+++ b/dialog/en-us/start.poll.email.dialog
@@ -1,0 +1,1 @@
+I will notify you of new mail.

--- a/dialog/en-us/stop.looking.for.dialog
+++ b/dialog/en-us/stop.looking.for.dialog
@@ -1,0 +1,1 @@
+I will stop to look for new mail by {email}

--- a/dialog/en-us/stop.poll.emails.dialog
+++ b/dialog/en-us/stop.poll.emails.dialog
@@ -1,0 +1,1 @@
+I will stop to look for new mail.

--- a/dialog/en-us/stop.poll.emails.last.email.removed.dialog
+++ b/dialog/en-us/stop.poll.emails.last.email.removed.dialog
@@ -1,0 +1,1 @@
+I will stop to look for new mail, because there are no email addresses you want to be notified of. If you want me to look for incoming emails, please instruct me to do so.

--- a/dialog/en-us/update.notify.data.dialog
+++ b/dialog/en-us/update.notify.data.dialog
@@ -1,0 +1,1 @@
+I updated your email preferences.

--- a/vocab/en-us/notify.intent
+++ b/vocab/en-us/notify.intent
@@ -1,0 +1,8 @@
+tell me of (mail | email | new mail | email)
+tell me when I get (mail | email | new mail | new email)
+tell me when I get (a mail | an email | email) (from | by) {sender}
+tell me of (mail | email) (from | by) {sender}
+notify me of (mail | email | new mail | new email)
+notify me of (mail | email | new mail | new email) (from | by) {sender}
+notify me when I get (mail | email | new mail | new email)
+notify me when I get (a mail | an email | email) (from | by) {sender}

--- a/vocab/en-us/stop.intent
+++ b/vocab/en-us/stop.intent
@@ -1,0 +1,8 @@
+do not notify me of (mail | email | new mail | new email)
+do not notify me of (mail | email | new mail | new email) (from | by) {sender}
+no longer notify me of (mail | email | new mail | new email)
+no longer notify me of (mail | email | new mail | new email) (from | by) {sender}
+do not tell me of (mail | email | new mail | new email)
+do not tell me of (mail | email | new mail | new email) (from | by) {sender}
+no longer tell me of (mail | email | new mail | new email)
+no longer tell me of (mail | email | new mail | new email) (from | by) {sender}


### PR DESCRIPTION
Resolves #4 

This PR implements notifications of unread emails.
The emails are marked as seen when discovered, because you would not want to be notified every minute that there is new mail. The default check my email intent will not mark them as seen.

The monitoring is implemented via repeating events and will therefore look for new mail every 60 seconds.

When stopping mycroft and reopening again, the notification settings are preserved and the skill will continue to look for new mail if it was instructed to do so.

It's also possible to supplement an email-address or name and the skill will only notify of emails by that sender. However you have to speak very clearly to get a good speech to text translation for emails.

Signed-off-by: florian <floriankothmeier@web.de>